### PR TITLE
checkSlidePosition regex fix

### DIFF
--- a/lib/revealjs-preview-view.coffee
+++ b/lib/revealjs-preview-view.coffee
@@ -81,7 +81,7 @@ class ReealjsPreviewView extends View
   checkSlidePosition: ->
     point = @editor.getCursorBufferPosition()
     forwardText = @editor.getTextInBufferRange([[0,0], point])
-    if result = forwardText.match(/^\r?\n---\r?\n$/g)
+    if result = forwardText.match(/\r?\n---\r?\n/g)
       result.length
     else
       0


### PR DESCRIPTION
Now opens the correct slide determined by cursor position.
